### PR TITLE
Check and use appropriate SDL2 flags for compilation and linking in OS X Makefile

### DIFF
--- a/osx/Makefile
+++ b/osx/Makefile
@@ -1,14 +1,17 @@
+CC = g++ 
 CFLAGS	:= -O3 -std=c++14
 
-CC = g++ 
+SDL_CFLAG := $(shell /usr/local/bin/sdl2-config --cflags)
+SDL_LFLAG := $(shell /usr/local/bin/sdl2-config --libs)
+
 SRC := ../src
 OBJS := objmemory.o bitblt.o main.o interpreter.o
 
 Smalltalk: $(OBJS) 
-	$(CC) -F/Library/Frameworks -framework SDL2  -o $@  $^
-	
+	$(CC) -F/Library/Frameworks $(SDL_LFLAG)  -o $@  $^
+
 main.o: $(SRC)/main.cpp
-	$(CC) $(CFLAGS) -I/Library/Frameworks/SDL2.framework/Headers -F/Library/Frameworks   -c $(SRC)/main.cpp
+	$(CC) $(CFLAGS) $(SDL_CFLAG) -F/Library/Frameworks   -c $(SRC)/main.cpp
 
 %.o: $(SRC)/%.cpp
 	$(CC) $(CFLAGS) -c $<  -o $@

--- a/osx/Makefile
+++ b/osx/Makefile
@@ -1,8 +1,8 @@
 CC = g++ 
 CFLAGS	:= -O3 -std=c++14
 
-SDL_CFLAG := $(shell /usr/local/bin/sdl2-config --cflags)
-SDL_LFLAG := $(shell /usr/local/bin/sdl2-config --libs)
+SDL_CFLAG := $(shell sdl2-config --cflags)
+SDL_LFLAG := $(shell sdl2-config --libs)
 
 SRC := ../src
 OBJS := objmemory.o bitblt.o main.o interpreter.o


### PR DESCRIPTION
SDL2 may have been install in various ways on OS X (direct build, Homebrew, etc.) so rather than using flags based on a canned location, the Makefile can instead use SDL2 to find the correct flags to use.

The only requirements are that SDL2 is installed and that `sdl2-config` is on the path.