### PR TITLE
Make it compile on macOS

### DIFF
--- a/osx/Makefile
+++ b/osx/Makefile
@@ -1,14 +1,14 @@
 CFLAGS	:= -O3 -std=c++14
 
-CC = g++ 
+CC = g++
 SRC := ../src
 OBJS := objmemory.o bitblt.o main.o interpreter.o
 
-Smalltalk: $(OBJS) 
-	$(CC) -F/Library/Frameworks -framework SDL2  -o $@  $^
-	
+Smalltalk: $(OBJS)
+	$(CC) -F/Library/Frameworks -L/usr/local/lib -lSDL2  -o $@  $^
+
 main.o: $(SRC)/main.cpp
-	$(CC) $(CFLAGS) -I/Library/Frameworks/SDL2.framework/Headers -F/Library/Frameworks   -c $(SRC)/main.cpp
+	$(CC) $(CFLAGS) -I/usr/local/include/SDL2 -D_THREAD_SAFE	 -F/Library/Frameworks   -c $(SRC)/main.cpp
 
 %.o: $(SRC)/%.cpp
 	$(CC) $(CFLAGS) -c $<  -o $@


### PR DESCRIPTION
Hi Dan,

I'm not a C/C++ developer so I'm not sure if this patch is appropriate. I found that SDL2 was on my machine installed by Homebrew. I guess as a dependency for some other tool. After googling around I discovered the `sdl2-config` and I just changed the arguments like they were printed by it. So now it compiles and runs on my machine (macOS 10.14.6).